### PR TITLE
Add FeatureRule struct tags

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -15,27 +15,27 @@ const (
 
 // Experiment defines a single experiment.
 type Experiment struct {
-	Key           string
-	Variations    []FeatureValue
-	Ranges        []Range
-	Meta          []VariationMeta
-	Filters       []Filter
-	Seed          string
-	Name          string
-	Phase         string
-	URLPatterns   []URLTarget
-	Weights       []float64
-	Condition     Condition
-	Coverage      *float64
-	Include       func() bool
-	Namespace     *Namespace
-	Force         *int
-	HashAttribute string
-	HashVersion   int
-	Active        bool
-	Status        ExperimentStatus
-	URL           *regexp.Regexp
-	Groups        []string
+	Key           string           `json:"key,omitempty"`
+	Variations    []FeatureValue   `json:"variations,omitempty"`
+	Ranges        []Range          `json:"ranges,omitempty"`
+	Meta          []VariationMeta  `json:"meta,omitempty"`
+	Filters       []Filter         `json:"filters,omitempty"`
+	Seed          string           `json:"seed,omitempty"`
+	Name          string           `json:"name,omitempty"`
+	Phase         string           `json:"phase,omitempty"`
+	URLPatterns   []URLTarget      `json:"urlPatterns,omitempty"`
+	Weights       []float64        `json:"weights,omitempty"`
+	Condition     Condition        `json:"condition,omitempty"`
+	Coverage      *float64         `json:"coverage,omitempty"`
+	Include       func() bool      `json:"include,omitempty"`
+	Namespace     *Namespace       `json:"namespace,omitempty"`
+	Force         *int             `json:"force,omitempty"`
+	HashAttribute string           `json:"hashAttribute,omitempty"`
+	HashVersion   int              `json:"hashVersion,omitempty"`
+	Active        bool             `json:"active,omitempty"`
+	Status        ExperimentStatus `json:"status,omitempty"`
+	URL           *regexp.Regexp   `json:"url,omitempty"`
+	Groups        []string         `json:"groups,omitempty"`
 }
 
 // NewExperiment creates an experiment with default settings: active,

--- a/feature_result.go
+++ b/feature_result.go
@@ -2,13 +2,13 @@ package growthbook
 
 // FeatureResult is the result of evaluating a feature.
 type FeatureResult struct {
-	Value            FeatureValue
-	Source           FeatureResultSource
-	On               bool
-	Off              bool
-	RuleID           string
-	Experiment       *Experiment
-	ExperimentResult *Result
+	Value            FeatureValue        `json:"value,omitempty"`
+	Source           FeatureResultSource `json:"source,omitempty"`
+	On               bool                `json:"on,omitempty"`
+	Off              bool                `json:"off,omitempty"`
+	RuleID           string              `json:"ruleId,omitempty"`
+	Experiment       *Experiment         `json:"experiment,omitempty"`
+	ExperimentResult *Result             `json:"experimentResult,omitempty"`
 }
 
 // BuildFeatureResult creates an FeatureResult value from a JSON

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -2,23 +2,23 @@ package growthbook
 
 // FeatureRule overrides the default value of a Feature.
 type FeatureRule struct {
-	ID            string
-	Condition     Condition
-	Force         FeatureValue
-	Variations    []FeatureValue
-	Weights       []float64
-	Key           string
-	HashAttribute string
-	HashVersion   int
-	Range         *Range
-	Coverage      *float64
-	Namespace     *Namespace
-	Ranges        []Range
-	Meta          []VariationMeta
-	Filters       []Filter
-	Seed          string
-	Name          string
-	Phase         string
+	ID            string          `json:"id,omitempty"`
+	Condition     Condition       `json:"condition,omitempty"`
+	Force         FeatureValue    `json:"force,omitempty"`
+	Variations    []FeatureValue  `json:"variations,omitempty"`
+	Weights       []float64       `json:"weights,omitempty"`
+	Key           string          `json:"key,omitempty"`
+	HashAttribute string          `json:"hashAttribute,omitempty"`
+	HashVersion   int             `json:"hashVersion,omitempty"`
+	Range         *Range          `json:"range,omitempty"`
+	Coverage      *float64        `json:"coverage,omitempty"`
+	Namespace     *Namespace      `json:"namespace,omitempty"`
+	Ranges        []Range         `json:"ranges,omitempty"`
+	Meta          []VariationMeta `json:"meta,omitempty"`
+	Filters       []Filter        `json:"filters,omitempty"`
+	Seed          string          `json:"seed,omitempty"`
+	Name          string          `json:"name,omitempty"`
+	Phase         string          `json:"phase,omitempty"`
 }
 
 // BuildFeatureRule creates an FeatureRule value from a generic JSON

--- a/filter.go
+++ b/filter.go
@@ -3,10 +3,10 @@ package growthbook
 // Filter represents a filter condition for experiment mutual
 // exclusion.
 type Filter struct {
-	Attribute   string
-	Seed        string
-	HashVersion int
-	Ranges      []Range
+	Attribute   string  `json:"attribute,omitempty"`
+	Seed        string  `json:"seed,omitempty"`
+	HashVersion int     `json:"hashVersion,omitempty"`
+	Ranges      []Range `json:"ranges,omitempty"`
 }
 
 func jsonFilter(v interface{}, typeName string, fieldName string) *Filter {

--- a/meta.go
+++ b/meta.go
@@ -3,9 +3,9 @@ package growthbook
 // VariationMeta represents meta-information that can be passed
 // through to tracking callbacks.
 type VariationMeta struct {
-	Passthrough bool
-	Key         string
-	Name        string
+	Passthrough bool   `json:"passthrough,omitempty"`
+	Key         string `json:"key,omitempty"`
+	Name        string `json:"name,omitempty"`
 }
 
 func jsonVariationMeta(v interface{}, typeName string, fieldName string) *VariationMeta {

--- a/range.go
+++ b/range.go
@@ -2,8 +2,8 @@ package growthbook
 
 // Range represents a single bucket range.
 type Range struct {
-	Min float64
-	Max float64
+	Min float64 `json:"min"`
+	Max float64 `json:"max"`
 }
 
 func (r *Range) InRange(n float64) bool {


### PR DESCRIPTION
The issue arises during the unmarshalling process of the `FeatureRule` object. Currently, the `FeatureRule` struct lacks the necessary tags to instruct the JSON library on how to map the field names properly. As a result, the field names in the JSON do not match the variable names in the struct.
For instance, the "Variations" field in the JSON does not correspond to "variations" in the struct, causing the mapping to fail.

When the `BuildFeatureRule` method is executed, the conditions within the switch statement are not properly fulfilled due to this mismatch in field names.
